### PR TITLE
Adjust home dirt particle effect colors

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -55,13 +55,15 @@ document.addEventListener('DOMContentLoaded', () => {
       const dirtContainer = document.getElementById('dirt-container');
       const vacuum = document.getElementById('vacuum-cleaner');
     const dirtParticles = [];
-    const particleCount = 50;
+    const particleCount = 30;
+    const colors = ['#0b8082', '#15d8dc'];
     const collisionDistance = 5;
 
     const createDirtParticles = () => {
       for (let i = 0; i < particleCount; i++) {
         const dirt = document.createElement('div');
         dirt.classList.add('dirt-particle');
+        dirt.style.backgroundColor = colors[Math.floor(Math.random() * colors.length)];
 
         const x = Math.random() * window.innerWidth;
         const y = Math.random() * window.innerHeight;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,9 @@
 @import "tailwindcss";
+
+:root {
+  --brand-dark: #0b8082;
+  --brand-light: #15d8dc;
+}
 /* Contenedor de suciedad */
 #dirt-container {
   position: fixed;
@@ -14,7 +19,7 @@
   position: absolute;
   width: 20px;
   height: 20px;
-  background-color: rgba(139, 69, 19, 0.7);
+  background-color: var(--brand-dark);
   border-radius: 50%;
   transform: translate(-50%, -50%);
   transition: opacity 0.2s ease;


### PR DESCRIPTION
## Summary
- tweak global variables for brand colors
- use brand colors for dirt particle style
- randomize particle color from dark/light green and reduce count

## Testing
- `npm run build` *(fails: astro not found)*