### PR TITLE
Add city selector for Santiago/Pucón navigation

### DIFF
--- a/docs/CITY_SELECTOR.md
+++ b/docs/CITY_SELECTOR.md
@@ -1,0 +1,120 @@
+# City Selector System
+
+Este documento explica cómo funciona el sistema de selector de ciudades para alternar entre Santiago y Pucón.
+
+## Componentes
+
+### CitySelector.astro
+Componente principal que renderiza el selector de ciudades en el header. Incluye:
+- Botones de alternar entre Santiago y Pucón
+- Persistencia en localStorage
+- Integración con el store centralizado
+- Diseño responsive
+
+### cityStore.ts
+Store centralizado que maneja:
+- Estado actual de la ciudad seleccionada
+- Persistencia en localStorage
+- Notificaciones a componentes suscritos
+- Eventos personalizados para componentes legacy
+
+### CityAwareContent.astro
+Componente de ejemplo que muestra cómo crear contenido que cambia según la ciudad seleccionada.
+
+## Uso
+
+### En componentes Astro con store:
+```typescript
+import { cityStore, type City, getCityDisplayName } from '../stores/cityStore.js';
+
+// Obtener ciudad actual
+const currentCity = cityStore.getCurrentCity();
+
+// Suscribirse a cambios
+const unsubscribe = cityStore.subscribe((city: City) => {
+  console.log('Ciudad cambiada a:', city);
+});
+
+// Cambiar ciudad programáticamente
+cityStore.setCity('pucon');
+```
+
+### En componentes que no usan el store:
+```javascript
+// Escuchar evento personalizado
+document.addEventListener('citychange', (e) => {
+  const city = e.detail.city;
+  console.log('Nueva ciudad:', city);
+});
+```
+
+### En páginas Astro:
+```astro
+---
+import { getCurrentCity, getCityDisplayName } from '../stores/cityStore.js';
+
+// Nota: Esto solo funciona en el servidor, para contenido dinámico usar componentes con script
+const serverCity = 'santiago'; // Valor por defecto en servidor
+---
+
+<div class="city-content" data-city="santiago">
+  Contenido para Santiago
+</div>
+<div class="city-content hidden" data-city="pucon">
+  Contenido para Pucón
+</div>
+
+<script>
+  import { cityStore } from '../stores/cityStore.js';
+  
+  cityStore.subscribe((city) => {
+    // Actualizar contenido dinámicamente
+    document.querySelectorAll('.city-content').forEach(content => {
+      content.classList.toggle('hidden', content.dataset.city !== city);
+    });
+  });
+</script>
+```
+
+## Estructura de datos
+
+```typescript
+type City = 'santiago' | 'pucon';
+
+interface CityData {
+  name: string;
+  displayName: string;
+}
+
+const CITIES = {
+  santiago: {
+    name: 'santiago',
+    displayName: 'Santiago'
+  },
+  pucon: {
+    name: 'pucon',
+    displayName: 'Pucón'
+  }
+};
+```
+
+## Funcionalidades
+
+1. **Persistencia**: La selección se guarda en localStorage
+2. **Sincronización**: Cambios se sincronizan entre pestañas del navegador
+3. **Eventos**: Se disparan eventos personalizados para componentes legacy
+4. **TypeScript**: Full type safety con tipos exportados
+5. **SSR Compatible**: Funciona con renderizado del servidor de Astro
+
+## Implementación en el Header
+
+El selector aparece:
+- En desktop: Al lado del logo
+- En mobile: Dentro del menú desplegable
+
+## Próximos pasos
+
+1. Implementar precios diferenciados por ciudad
+2. Crear páginas específicas por ciudad
+3. Agregar contenido geolocalizado
+4. Implementar servicios específicos por ciudad

--- a/src/components/CityAwareContent.astro
+++ b/src/components/CityAwareContent.astro
@@ -1,0 +1,126 @@
+---
+// Example component that shows different content based on selected city
+// Other pages can use this pattern to display city-specific information
+---
+
+<div id="city-content">
+  <div class="city-indicator">
+    <span id="current-city-name">Santiago</span>
+  </div>
+  
+  <div id="city-specific-content">
+    <div class="city-content" data-city="santiago">
+      <h3>Servicios en Santiago</h3>
+      <p>Cobertura en toda la Región Metropolitana</p>
+    </div>
+    
+    <div class="city-content hidden" data-city="pucon">
+      <h3>Servicios en Pucón</h3>
+      <p>Cobertura en Pucón y alrededores</p>
+    </div>
+  </div>
+</div>
+
+<script>
+  import { cityStore, type City, getCityDisplayName } from '../stores/cityStore.js';
+
+  class CityAwareContent {
+    private unsubscribe?: () => void;
+
+    constructor() {
+      this.init();
+    }
+
+    private init(): void {
+      this.subscribeToStore();
+      this.updateContent();
+    }
+
+    private subscribeToStore(): void {
+      this.unsubscribe = cityStore.subscribe((city: City) => {
+        this.updateContent();
+      });
+    }
+
+    private updateContent(): void {
+      const currentCity = cityStore.getCurrentCity();
+      const cityNameElement = document.getElementById('current-city-name');
+      const cityContents = document.querySelectorAll('.city-content');
+
+      // Update city name indicator
+      if (cityNameElement) {
+        cityNameElement.textContent = getCityDisplayName(currentCity);
+      }
+
+      // Show/hide city-specific content
+      cityContents.forEach(content => {
+        const contentElement = content as HTMLElement;
+        const contentCity = contentElement.dataset.city;
+        
+        if (contentCity === currentCity) {
+          contentElement.classList.remove('hidden');
+        } else {
+          contentElement.classList.add('hidden');
+        }
+      });
+    }
+
+    public destroy(): void {
+      if (this.unsubscribe) {
+        this.unsubscribe();
+      }
+    }
+  }
+
+  let content: CityAwareContent;
+
+  const initializeContent = () => {
+    if (content) {
+      content.destroy();
+    }
+    content = new CityAwareContent();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeContent);
+  } else {
+    initializeContent();
+  }
+</script>
+
+<style>
+  .city-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background-color: #f3f4f6;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    font-weight: 500;
+    color: #374151;
+    margin-bottom: 1rem;
+  }
+
+  .city-indicator::before {
+    content: "📍";
+    font-size: 1rem;
+  }
+
+  .city-content {
+    transition: opacity 0.3s ease;
+  }
+
+  .city-content.hidden {
+    display: none;
+  }
+
+  .city-content h3 {
+    margin: 0 0 0.5rem 0;
+    color: #0facaf;
+  }
+
+  .city-content p {
+    margin: 0;
+    color: #6b7280;
+  }
+</style>

--- a/src/components/CitySelector.astro
+++ b/src/components/CitySelector.astro
@@ -1,0 +1,183 @@
+---
+// CitySelector component for Santiago/Pucón selection
+---
+
+<div class="city-selector">
+  <div class="selector-label">
+    <span class="label-text">Ciudad:</span>
+  </div>
+  <div class="selector-tabs">
+    <button 
+      id="santiago-tab" 
+      class="city-tab active" 
+      data-city="santiago"
+      aria-label="Seleccionar Santiago"
+    >
+      Santiago
+    </button>
+    <button 
+      id="pucon-tab" 
+      class="city-tab" 
+      data-city="pucon"
+      aria-label="Seleccionar Pucón"
+    >
+      Pucón
+    </button>
+  </div>
+</div>
+
+<script>
+  import { cityStore, type City } from '../stores/cityStore.js';
+
+  // City selector functionality using the centralized store
+  class CitySelector {
+    private unsubscribe?: () => void;
+
+    constructor() {
+      this.init();
+    }
+
+    private init(): void {
+      this.setupEventListeners();
+      this.subscribeToStore();
+      this.updateUI();
+    }
+
+    private setupEventListeners(): void {
+      const tabs = document.querySelectorAll('.city-tab');
+      tabs.forEach(tab => {
+        tab.addEventListener('click', (e) => {
+          const target = e.target as HTMLButtonElement;
+          const city = target.dataset.city;
+          if (city && (city === 'santiago' || city === 'pucon')) {
+            cityStore.setCity(city as City);
+          }
+        });
+      });
+    }
+
+    private subscribeToStore(): void {
+      this.unsubscribe = cityStore.subscribe((city: City) => {
+        this.updateUI();
+      });
+    }
+
+    private updateUI(): void {
+      const currentCity = cityStore.getCurrentCity();
+      const tabs = document.querySelectorAll('.city-tab');
+      
+      tabs.forEach(tab => {
+        const tabElement = tab as HTMLElement;
+        const city = tabElement.dataset.city;
+        if (city === currentCity) {
+          tabElement.classList.add('active');
+          tabElement.setAttribute('aria-pressed', 'true');
+        } else {
+          tabElement.classList.remove('active');
+          tabElement.setAttribute('aria-pressed', 'false');
+        }
+      });
+    }
+
+    public destroy(): void {
+      if (this.unsubscribe) {
+        this.unsubscribe();
+      }
+    }
+  }
+
+  let selector: CitySelector;
+
+  // Initialize when DOM is ready
+  const initializeSelector = () => {
+    if (selector) {
+      selector.destroy();
+    }
+    selector = new CitySelector();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeSelector);
+  } else {
+    initializeSelector();
+  }
+
+  // Initialize the store
+  cityStore.initialize();
+</script>
+
+<style>
+  .city-selector {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: 1rem;
+  }
+
+  .selector-label {
+    display: none;
+  }
+
+  @media (min-width: 1024px) {
+    .selector-label {
+      display: block;
+    }
+  }
+
+  .label-text {
+    font-size: 0.875rem;
+    color: #6b7280;
+    white-space: nowrap;
+  }
+
+  .selector-tabs {
+    display: flex;
+    background-color: #f3f4f6;
+    border-radius: 0.5rem;
+    padding: 0.125rem;
+    gap: 0.125rem;
+  }
+
+  .city-tab {
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: none;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    background-color: transparent;
+    color: #6b7280;
+    white-space: nowrap;
+  }
+
+  .city-tab:hover {
+    background-color: #e5e7eb;
+    color: #374151;
+  }
+
+  .city-tab.active {
+    background-color: white;
+    color: #0facaf;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  }
+
+  .city-tab:focus {
+    outline: none;
+    ring: 2px;
+    ring-color: #0facaf;
+    ring-opacity: 0.5;
+  }
+
+  /* Mobile responsive adjustments */
+  @media (max-width: 640px) {
+    .city-selector {
+      margin-left: 0.5rem;
+    }
+    
+    .city-tab {
+      padding: 0.25rem 0.5rem;
+      font-size: 0.75rem;
+    }
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,6 @@
 ---
+import CitySelector from './CitySelector.astro';
+
 const pathname = Astro.url.pathname;
 
 // Función para determinar si un enlace está activo
@@ -22,8 +24,13 @@ const navLinks = [
 <header class="bg-white shadow-sm fixed w-full top-0 z-50">
   <div class="max-w-7xl mx-auto px-4">
     <nav class="flex justify-between items-center h-16">
-      <div class="logo">
-        SO<span class="logo-highlight">PLAO</span>.CL
+      <div class="flex items-center">
+        <div class="logo">
+          SO<span class="logo-highlight">PLAO</span>.CL
+        </div>
+        <div class="hidden lg:block">
+          <CitySelector />
+        </div>
       </div>
 
       <button id="menuButton" class="lg:hidden p-2" aria-label="Menu">
@@ -73,6 +80,9 @@ const navLinks = [
               </a>
             ))
           }
+          <div class="lg:hidden pt-4 border-t border-gray-200">
+            <CitySelector />
+          </div>
         </div>
       </div>
     </nav>

--- a/src/stores/cityStore.ts
+++ b/src/stores/cityStore.ts
@@ -1,0 +1,124 @@
+// City store for managing selected city state across the application
+export type City = 'santiago' | 'pucon';
+
+export interface CityData {
+  name: string;
+  displayName: string;
+}
+
+export const CITIES: Record<City, CityData> = {
+  santiago: {
+    name: 'santiago',
+    displayName: 'Santiago'
+  },
+  pucon: {
+    name: 'pucon',
+    displayName: 'Pucón'
+  }
+};
+
+class CityStore {
+  private static instance: CityStore;
+  private currentCity: City = 'santiago';
+  private readonly STORAGE_KEY = 'selected-city';
+  private listeners: ((city: City) => void)[] = [];
+
+  private constructor() {
+    this.loadFromStorage();
+    this.setupStorageListener();
+  }
+
+  public static getInstance(): CityStore {
+    if (!CityStore.instance) {
+      CityStore.instance = new CityStore();
+    }
+    return CityStore.instance;
+  }
+
+  private loadFromStorage(): void {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem(this.STORAGE_KEY);
+      if (stored && this.isValidCity(stored)) {
+        this.currentCity = stored as City;
+      }
+    }
+  }
+
+  private saveToStorage(): void {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(this.STORAGE_KEY, this.currentCity);
+    }
+  }
+
+  private setupStorageListener(): void {
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', (e) => {
+        if (e.key === this.STORAGE_KEY && e.newValue && this.isValidCity(e.newValue)) {
+          this.currentCity = e.newValue as City;
+          this.notifyListeners();
+        }
+      });
+    }
+  }
+
+  private isValidCity(city: string): boolean {
+    return city === 'santiago' || city === 'pucon';
+  }
+
+  private notifyListeners(): void {
+    this.listeners.forEach(listener => listener(this.currentCity));
+  }
+
+  public getCurrentCity(): City {
+    return this.currentCity;
+  }
+
+  public setCity(city: City): void {
+    if (this.currentCity !== city) {
+      this.currentCity = city;
+      this.saveToStorage();
+      this.notifyListeners();
+      
+      // Dispatch custom event for components that don't use the store directly
+      if (typeof window !== 'undefined') {
+        const event = new CustomEvent('citychange', {
+          detail: { city: city },
+          bubbles: true
+        });
+        document.dispatchEvent(event);
+      }
+    }
+  }
+
+  public getCityData(city?: City): CityData {
+    return CITIES[city || this.currentCity];
+  }
+
+  public subscribe(listener: (city: City) => void): () => void {
+    this.listeners.push(listener);
+    
+    // Return unsubscribe function
+    return () => {
+      const index = this.listeners.indexOf(listener);
+      if (index > -1) {
+        this.listeners.splice(index, 1);
+      }
+    };
+  }
+
+  public initialize(): void {
+    // Method to be called when the app initializes
+    this.loadFromStorage();
+    this.notifyListeners();
+  }
+}
+
+// Export singleton instance
+export const cityStore = CityStore.getInstance();
+
+// Utility functions for easier usage
+export const getCurrentCity = (): City => cityStore.getCurrentCity();
+export const setCurrentCity = (city: City): void => cityStore.setCity(city);
+export const getCityDisplayName = (city?: City): string => cityStore.getCityData(city).displayName;
+export const subscribeToCityChanges = (listener: (city: City) => void): (() => void) => 
+  cityStore.subscribe(listener);


### PR DESCRIPTION
Closes #13

## Summary
Implemented a comprehensive city selector system that allows users to toggle between Santiago and Pucón services. The selector is integrated into the main navigation and persists user selection across sessions.

## Features implemented
✅ **CitySelector Component**
- Toggle buttons for Santiago/Pucón selection
- Responsive design (desktop: next to logo, mobile: in dropdown menu)
- Accessibility attributes (aria-pressed, aria-label)

✅ **Centralized State Management**
- TypeScript store with full type safety
- localStorage persistence across sessions
- Cross-tab synchronization
- Custom event dispatch for legacy components

✅ **Header Integration**
- Added to desktop navigation bar
- Included in mobile dropdown menu
- Consistent styling with existing design

✅ **Developer Experience**
- Comprehensive documentation in docs/CITY_SELECTOR.md
- Example CityAwareContent component
- Utility functions for easy integration
- TypeScript interfaces and types

## Technical details
- **Store**: Singleton pattern with subscriber notifications
- **Persistence**: localStorage with storage event listeners
- **Events**: Custom 'citychange' events for broader compatibility  
- **Types**: Full TypeScript coverage with City and CityData interfaces
- **SSR Compatible**: Works with Astro's server-side rendering

## Usage example
```typescript
import { cityStore, getCurrentCity, setCurrentCity } from '../stores/cityStore.js';

// Get current city
const city = getCurrentCity(); // 'santiago' | 'pucon'

// Subscribe to changes
const unsubscribe = cityStore.subscribe((city) => {
  console.log('City changed to:', city);
});

// Change city programmatically
setCurrentCity('pucon');
```

## Test plan
- [x] City selector renders in header (desktop and mobile)
- [x] Clicking toggles between Santiago and Pucón
- [x] Selection persists after page reload
- [x] Selection syncs across browser tabs
- [x] Mobile menu includes city selector
- [x] TypeScript compilation passes
- [ ] Visual regression testing on different screen sizes
- [ ] Cross-browser compatibility testing
- [ ] Accessibility testing with screen readers

## Next steps
This foundation enables:
- Issue #14: Price differentiation by city
- Issue #15: ServiceCard updates for city-specific pricing  
- Issue #17: Pucón-specific services page
- Issue #19: City-specific pricing tables