### PR TITLE
feat: add specific pricing tiers for specialized services

### DIFF
--- a/src/data/cityPricing.ts
+++ b/src/data/cityPricing.ts
@@ -24,35 +24,66 @@ export const basePrices = {
 // Specialized services base prices
 export const specializedBasePrices = {
   carpetCleaning: [
-    { label: "Cotización Personalizada", price: "Según Metraje" }
+    { label: "Hasta 10 m²", price: "$ 35.000" },
+    { label: "10-30 m²", price: "$ 65.000" },
+    { label: "30-50 m²", price: "$ 95.000" },
+    { label: "Más de 50 m²", price: "$ 1.800 x m²" }
   ] as PriceItem[],
   
   tapestryUpholstery: [
-    { label: "Cotización Personalizada", price: "Según Cantidad" }
+    { label: "Sillón individual", price: "$ 15.000" },
+    { label: "Sofá 2-3 cuerpos", price: "$ 25.000" },
+    { label: "Sofá esquinero", price: "$ 35.000" },
+    { label: "Silla de comedor (c/u)", price: "$ 8.000" }
   ] as PriceItem[],
   
   mattressCleaning: [
-    { label: "Cotización Personalizada", price: "Según Tamaño" }
+    { label: "Individual (1 plaza)", price: "$ 20.000" },
+    { label: "Matrimonial (2 plazas)", price: "$ 30.000" },
+    { label: "Queen/King size", price: "$ 40.000" },
+    { label: "Box spring completo", price: "$ 55.000" }
   ] as PriceItem[],
   
   kitchenCleaning: [
-    { label: "Cotización Personalizada", price: "Según Área" }
+    { label: "Cocina residencial básica", price: "$ 45.000" },
+    { label: "Cocina con isla", price: "$ 65.000" },
+    { label: "Cocina americana", price: "$ 35.000" },
+    { label: "Limpieza de horno", price: "$ 15.000" }
   ] as PriceItem[],
   
   industrialKitchen: [
-    { label: "Cotización Personalizada", price: "Según Área" }
+    { label: "Cocina comercial pequeña", price: "$ 150.000" },
+    { label: "Cocina comercial mediana", price: "$ 250.000" },
+    { label: "Cocina industrial grande", price: "$ 400.000" },
+    { label: "Mantenimiento mensual", price: "$ 80.000" }
   ] as PriceItem[],
   
   floorRestoration: [
-    { label: "Cotización Personalizada", price: "Según Metraje" }
+    { label: "Parquet/madera 10-30 m²", price: "$ 45.000" },
+    { label: "Parquet/madera 30-60 m²", price: "$ 80.000" },
+    { label: "Mármol/granito por m²", price: "$ 2.500" },
+    { label: "Cerámico/porcelanato por m²", price: "$ 1.800" }
   ] as PriceItem[],
   
   bathroomCleaning: [
-    { label: "Cotización Personalizada", price: "Según Cantidad" }
+    { label: "1 baño residencial", price: "$ 25.000" },
+    { label: "2-3 baños", price: "$ 45.000" },
+    { label: "Baño principal con tina", price: "$ 35.000" },
+    { label: "Baño comercial", price: "$ 40.000" }
   ] as PriceItem[],
   
   windowCleaning: [
-    { label: "Cotización Personalizada", price: "Según Área" }
+    { label: "Hasta 10 ventanas", price: "$ 25.000" },
+    { label: "10-20 ventanas", price: "$ 40.000" },
+    { label: "20-40 ventanas", price: "$ 65.000" },
+    { label: "Edificio comercial", price: "$ 2.000 x ventana" }
+  ] as PriceItem[],
+  
+  wallCleaning: [
+    { label: "Hasta 50 m² de muro", price: "$ 60.000" },
+    { label: "50-100 m² de muro", price: "$ 110.000" },
+    { label: "100-200 m² de muro", price: "$ 200.000" },
+    { label: "Muro industrial por m²", price: "$ 1.200" }
   ] as PriceItem[]
 };
 
@@ -91,42 +122,47 @@ export const mainServicesPricing = {
 export const specializedServicesPricing = {
   carpetCleaning: createCityPricing(
     specializedBasePrices.carpetCleaning,
-    [{ label: "Cotización Personalizada", price: "Según Metraje + Traslado" }]
+    applyPriceAdjustment(specializedBasePrices.carpetCleaning, cityAdjustments.pucon)
   ),
   
   tapestryUpholstery: createCityPricing(
     specializedBasePrices.tapestryUpholstery,
-    [{ label: "Cotización Personalizada", price: "Según Cantidad + Traslado" }]
+    applyPriceAdjustment(specializedBasePrices.tapestryUpholstery, cityAdjustments.pucon)
   ),
   
   mattressCleaning: createCityPricing(
     specializedBasePrices.mattressCleaning,
-    [{ label: "Cotización Personalizada", price: "Según Tamaño + Traslado" }]
+    applyPriceAdjustment(specializedBasePrices.mattressCleaning, cityAdjustments.pucon)
   ),
   
   kitchenCleaning: createCityPricing(
     specializedBasePrices.kitchenCleaning,
-    [{ label: "Cotización Personalizada", price: "Según Área + Traslado" }]
+    applyPriceAdjustment(specializedBasePrices.kitchenCleaning, cityAdjustments.pucon)
   ),
   
   industrialKitchen: createCityPricing(
     specializedBasePrices.industrialKitchen,
-    [{ label: "Cotización Personalizada", price: "Según Área + Traslado" }]
+    applyPriceAdjustment(specializedBasePrices.industrialKitchen, cityAdjustments.pucon)
   ),
   
   floorRestoration: createCityPricing(
     specializedBasePrices.floorRestoration,
-    [{ label: "Cotización Personalizada", price: "Según Metraje + Traslado" }]
+    applyPriceAdjustment(specializedBasePrices.floorRestoration, cityAdjustments.pucon)
   ),
   
   bathroomCleaning: createCityPricing(
     specializedBasePrices.bathroomCleaning,
-    [{ label: "Cotización Personalizada", price: "Según Cantidad + Traslado" }]
+    applyPriceAdjustment(specializedBasePrices.bathroomCleaning, cityAdjustments.pucon)
   ),
   
   windowCleaning: createCityPricing(
     specializedBasePrices.windowCleaning,
-    [{ label: "Cotización Personalizada", price: "Según Área + Traslado" }]
+    applyPriceAdjustment(specializedBasePrices.windowCleaning, cityAdjustments.pucon)
+  ),
+  
+  wallCleaning: createCityPricing(
+    specializedBasePrices.wallCleaning,
+    applyPriceAdjustment(specializedBasePrices.wallCleaning, cityAdjustments.pucon)
   )
 };
 

--- a/src/pages/servicios.astro
+++ b/src/pages/servicios.astro
@@ -71,7 +71,7 @@ const specializedServices: Service[] = [
     title: "Limpieza Industrial de Muros",
     description: "Limpieza profunda para muros en entornos industriales y comerciales.",
     image: "/images/wall_clean.jpeg",
-    prices: specializedServicesPricing.kitchenCleaning, // Using kitchen cleaning pricing structure
+    prices: specializedServicesPricing.wallCleaning,
     direction: 'right'
   },
   {


### PR DESCRIPTION
## Summary
- Replace generic "Cotización Personalizada" with detailed pricing structure for all specialized services
- Add tiered pricing based on size, area, or quantity for each service type
- Apply automatic 20% price adjustment for Pucón services
- Fix wall cleaning service to use correct pricing structure instead of kitchen cleaning

## Services Updated
- **Carpet Cleaning**: 4 tiers based on m² coverage
- **Tapestry/Upholstery**: Individual, sofa, corner sofa, dining chairs
- **Mattress Cleaning**: Individual, matrimonial, queen/king, box spring
- **Kitchen Cleaning**: Residential basic, with island, american style, oven cleaning
- **Industrial Kitchen**: Small, medium, large commercial + monthly maintenance
- **Floor Restoration**: Wood/parquet tiers + per m² for marble and ceramic
- **Bathroom Cleaning**: 1 bathroom, 2-3 bathrooms, with tub, commercial
- **Window Cleaning**: Up to 10, 10-20, 20-40 windows + commercial rate
- **Wall Cleaning**: 50m², 50-100m², 100-200m² + industrial rate per m²

## Technical Changes
- Updated `src/data/cityPricing.ts` with comprehensive pricing structures
- Fixed wall cleaning service reference in `src/pages/servicios.astro`
- All pricing automatically applies 20% increase for Pucón services

Resolves #16