### PR TITLE
Eliminar 'Pucón' de ubicaciones

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,4 @@
 ---
-import CitySelector from './CitySelector.astro';
-
 const pathname = Astro.url.pathname;
 
 // Función para determinar si un enlace está activo
@@ -27,9 +25,6 @@ const navLinks = [
       <div class="flex items-center">
         <div class="logo">
           SO<span class="logo-highlight">PLAO</span>.CL
-        </div>
-        <div class="hidden lg:block">
-          <CitySelector />
         </div>
       </div>
 
@@ -80,9 +75,6 @@ const navLinks = [
               </a>
             ))
           }
-          <div class="lg:hidden pt-4 border-t border-gray-200">
-            <CitySelector />
-          </div>
         </div>
       </div>
     </nav>

--- a/src/components/ServiceCard.astro
+++ b/src/components/ServiceCard.astro
@@ -14,9 +14,8 @@ interface Props {
 
 const { title, description, prices, image, direction, includes, extras } = Astro.props;
 
-// Get default prices for server-side rendering (Santiago by default)
-const santiagoprices = getPricesForCity(prices, 'santiago');
-const puconPrices = getPricesForCity(prices, 'pucon');
+// Get prices for Santiago (only city available)
+const servicePrices = getPricesForCity(prices, 'santiago');
 ---
 <div
   class="w-full lg:w-1/2"
@@ -62,85 +61,22 @@ const puconPrices = getPricesForCity(prices, 'pucon');
         </div>
       )}
 
-      <div class="city-pricing-container">
-        <!-- City indicator -->
-        <div class="city-indicator mb-3 text-center">
-          <span class="current-city-name text-sm text-gray-500 font-medium">Santiago</span>
-        </div>
-        
+      <div class="pricing-container">
         <!-- Price display -->
         <div class="pricing-display flex flex-col items-center space-y-1 lg:space-y-2">
-          <!-- Santiago prices (default visible) -->
-          <div class="city-prices" data-city="santiago">
-            {santiagoprices.map(item => (
-              <div class="w-full flex justify-center items-center space-x-4 text-sm lg:text-base">
-                <span class="font-medium text-right min-w-[100px]">{item.label}</span>
-                <span>:</span>
-                <span class="service-price font-bold min-w-[80px] text-left">{item.price}</span>
-              </div>
-            ))}
-          </div>
-          
-          <!-- Pucón prices (hidden by default) -->
-          <div class="city-prices hidden" data-city="pucon">
-            {puconPrices.map(item => (
-              <div class="w-full flex justify-center items-center space-x-4 text-sm lg:text-base">
-                <span class="font-medium text-right min-w-[100px]">{item.label}</span>
-                <span>:</span>
-                <span class="service-price font-bold min-w-[80px] text-left">{item.price}</span>
-              </div>
-            ))}
-          </div>
+          {servicePrices.map(item => (
+            <div class="w-full flex justify-center items-center space-x-4 text-sm lg:text-base">
+              <span class="font-medium text-right min-w-[100px]">{item.label}</span>
+              <span>:</span>
+              <span class="service-price font-bold min-w-[80px] text-left">{item.price}</span>
+            </div>
+          ))}
         </div>
       </div>
     </div>
   </div>
 </div>
 
-<script define:vars={{ title }}>
-  // Simple city change handler without imports
-  function updateServiceCardPrices() {
-    const containers = document.querySelectorAll('.city-pricing-container');
-    containers.forEach(container => {
-      const serviceTitle = container.closest('.service-card')?.querySelector('.service-title')?.textContent;
-      if (serviceTitle === title) {
-        handleCityChange(container);
-      }
-    });
-  }
-
-  function handleCityChange(container) {
-    // Listen for city change events
-    document.addEventListener('citychange', (e) => {
-      const currentCity = e.detail.city;
-      const cityNameElement = container.querySelector('.current-city-name');
-      const cityContainers = container.querySelectorAll('.city-prices');
-
-      // Update city name indicator
-      if (cityNameElement) {
-        cityNameElement.textContent = currentCity === 'santiago' ? 'Santiago' : 'Pucón';
-      }
-
-      // Show/hide appropriate price container
-      cityContainers.forEach(priceContainer => {
-        const containerCity = priceContainer.dataset.city;
-        
-        if (containerCity === currentCity) {
-          priceContainer.classList.remove('hidden');
-        } else {
-          priceContainer.classList.add('hidden');
-        }
-      });
-    });
-  }
-
-  // Initialize when DOM is ready
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', updateServiceCardPrices);
-  } else {
-    updateServiceCardPrices();
-  }
-</script>
 
 <style>
   :root {
@@ -175,27 +111,7 @@ const puconPrices = getPricesForCity(prices, 'pucon');
     transform: scale(1.05);
   }
 
-  .city-indicator {
-    border-bottom: 1px solid #e5e7eb;
-    padding-bottom: 0.5rem;
-  }
-
-  .current-city-name {
-    color: var(--color-primary);
-    font-weight: 500;
-  }
-
-  .current-city-name::before {
-    content: "📍 ";
-    font-size: 0.875rem;
-  }
-
-  .pricing-display .city-prices {
-    transition: opacity 0.3s ease;
+  .pricing-display {
     width: 100%;
-  }
-
-  .pricing-display .city-prices.hidden {
-    display: none;
   }
 </style>

--- a/src/data/cityPricing.ts
+++ b/src/data/cityPricing.ts
@@ -75,97 +75,85 @@ export const specializedBasePrices = {
   ] as PriceItem[]
 };
 
-// Price adjustments by city
+// Price adjustments by city (Santiago only)
 export const cityAdjustments: Record<string, PriceAdjustment> = {
   santiago: {
     // Santiago uses base prices (no adjustment)
-  },
-  pucon: {
-    // Pucón prices are generally 20% higher due to location and travel costs
-    multiplier: 1.20,
-    // Some custom adjustments for specific services
-    customPrices: undefined // Will be overridden per service if needed
   }
 };
 
-// Generate city-specific pricing for main services
+// Generate city-specific pricing for main services (Santiago only)
 export const mainServicesPricing = {
   conventional: createCityPricing(
     basePrices.conventional,
-    applyPriceAdjustment(basePrices.conventional, cityAdjustments.pucon)
+    basePrices.conventional
   ),
-  
+
   deepCleaning: createCityPricing(
     basePrices.deepCleaning,
-    applyPriceAdjustment(basePrices.deepCleaning, cityAdjustments.pucon)
+    basePrices.deepCleaning
   ),
-  
+
   endOfRent: createCityPricing(
     basePrices.endOfRent,
-    [{ label: "Cotización Personalizada", price: "Solicitar Presupuesto + Traslado" }]
+    basePrices.endOfRent
   )
 };
 
-// Generate city-specific pricing for specialized services
+// Generate city-specific pricing for specialized services (Santiago only)
 export const specializedServicesPricing = {
   carpetCleaning: createCityPricing(
     specializedBasePrices.carpetCleaning,
-    applyPriceAdjustment(specializedBasePrices.carpetCleaning, cityAdjustments.pucon)
+    specializedBasePrices.carpetCleaning
   ),
-  
+
   tapestryUpholstery: createCityPricing(
     specializedBasePrices.tapestryUpholstery,
-    applyPriceAdjustment(specializedBasePrices.tapestryUpholstery, cityAdjustments.pucon)
+    specializedBasePrices.tapestryUpholstery
   ),
-  
+
   mattressCleaning: createCityPricing(
     specializedBasePrices.mattressCleaning,
-    applyPriceAdjustment(specializedBasePrices.mattressCleaning, cityAdjustments.pucon)
+    specializedBasePrices.mattressCleaning
   ),
-  
+
   kitchenCleaning: createCityPricing(
     specializedBasePrices.kitchenCleaning,
-    applyPriceAdjustment(specializedBasePrices.kitchenCleaning, cityAdjustments.pucon)
+    specializedBasePrices.kitchenCleaning
   ),
-  
+
   industrialKitchen: createCityPricing(
     specializedBasePrices.industrialKitchen,
-    applyPriceAdjustment(specializedBasePrices.industrialKitchen, cityAdjustments.pucon)
+    specializedBasePrices.industrialKitchen
   ),
-  
+
   floorRestoration: createCityPricing(
     specializedBasePrices.floorRestoration,
-    applyPriceAdjustment(specializedBasePrices.floorRestoration, cityAdjustments.pucon)
+    specializedBasePrices.floorRestoration
   ),
-  
+
   bathroomCleaning: createCityPricing(
     specializedBasePrices.bathroomCleaning,
-    applyPriceAdjustment(specializedBasePrices.bathroomCleaning, cityAdjustments.pucon)
+    specializedBasePrices.bathroomCleaning
   ),
-  
+
   windowCleaning: createCityPricing(
     specializedBasePrices.windowCleaning,
-    applyPriceAdjustment(specializedBasePrices.windowCleaning, cityAdjustments.pucon)
+    specializedBasePrices.windowCleaning
   ),
-  
+
   wallCleaning: createCityPricing(
     specializedBasePrices.wallCleaning,
-    applyPriceAdjustment(specializedBasePrices.wallCleaning, cityAdjustments.pucon)
+    specializedBasePrices.wallCleaning
   )
 };
 
-// City-specific information
+// City-specific information (Santiago only)
 export const cityInfo = {
   santiago: {
     name: 'Santiago',
     displayName: 'Santiago',
     coverage: 'Región Metropolitana',
     additionalInfo: 'Sin costo adicional de traslado'
-  },
-  pucon: {
-    name: 'pucon',
-    displayName: 'Pucón',
-    coverage: 'Pucón y alrededores',
-    additionalInfo: 'Incluye costo de traslado desde Santiago'
   }
 } as const;

--- a/src/stores/cityStore.ts
+++ b/src/stores/cityStore.ts
@@ -1,5 +1,5 @@
-// City store for managing selected city state across the application
-export type City = 'santiago' | 'pucon';
+// City store for managing city state (Santiago only)
+export type City = 'santiago';
 
 export interface CityData {
   name: string;
@@ -10,10 +10,6 @@ export const CITIES: Record<City, CityData> = {
   santiago: {
     name: 'santiago',
     displayName: 'Santiago'
-  },
-  pucon: {
-    name: 'pucon',
-    displayName: 'Pucón'
   }
 };
 
@@ -62,7 +58,7 @@ class CityStore {
   }
 
   private isValidCity(city: string): boolean {
-    return city === 'santiago' || city === 'pucon';
+    return city === 'santiago';
   }
 
   private notifyListeners(): void {

--- a/src/types/pricing.ts
+++ b/src/types/pricing.ts
@@ -7,10 +7,9 @@ export interface PriceItem {
   price: string;
 }
 
-// City-specific pricing structure
+// City-specific pricing structure (Santiago only)
 export interface CityPricing {
   santiago: PriceItem[];
-  pucon: PriceItem[];
 }
 
 // Legacy price structure for backward compatibility
@@ -32,10 +31,9 @@ export interface Service {
 
 // Type guard to check if prices use city-based structure
 export function isCityPricing(prices: ServicePrices): prices is CityPricing {
-  return typeof prices === 'object' && 
-         !Array.isArray(prices) && 
-         'santiago' in prices && 
-         'pucon' in prices;
+  return typeof prices === 'object' &&
+         !Array.isArray(prices) &&
+         'santiago' in prices;
 }
 
 // Type guard to check if prices use legacy structure
@@ -53,14 +51,13 @@ export function getPricesForCity(prices: ServicePrices, city: City): PriceItem[]
   return prices;
 }
 
-// Utility function to create city-specific pricing
+// Utility function to create city-specific pricing (Santiago only)
 export function createCityPricing(
   santiagoprices: PriceItem[],
-  puconPrices: PriceItem[]
+  _puconPrices?: PriceItem[]  // Keep for backward compatibility but unused
 ): CityPricing {
   return {
-    santiago: santiagoprices,
-    pucon: puconPrices
+    santiago: santiagoprices
   };
 }
 


### PR DESCRIPTION
## Summary
- Elimina soporte para la ciudad de Pucón
- Los servicios ahora solo están disponibles en Santiago (Región Metropolitana)
- Simplifica la estructura de código al remover funcionalidad multi-ciudad

## Changes
### UI Changes
- ❌ Removido selector de ciudad del Header (desktop y mobile)
- ❌ Removido indicador de ciudad en ServiceCard
- ✅ Interfaz más limpia y enfocada

### Code Changes
- **Header.astro**: Eliminado import y uso de CitySelector
- **ServiceCard.astro**: 
  - Removidos precios de Pucón
  - Eliminado event listener de cambio de ciudad
  - Simplificado para mostrar solo precios de Santiago
- **cityStore.ts**: 
  - Type `City` ahora solo acepta 'santiago'
  - Removida validación para Pucón
  - Simplificada estructura CITIES
- **cityPricing.ts**: 
  - Eliminados ajustes de precio para Pucón
  - Removida información de ciudad Pucón
  - Simplificados exports de pricing
- **pricing.ts**: 
  - Actualizada interfaz CityPricing
  - Ajustado type guard isCityPricing
  - Función createCityPricing mantiene compatibilidad

### Benefits
- Código más simple y mantenible
- Menor superficie de bugs
- UI más clara sin opciones innecesarias
- Mejor rendimiento (menos event listeners)

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed city selection from the header; the app now defaults to Santiago.
  - Unified pricing to a single city (Santiago); Pucon-specific options and adjustments are removed.
  - Simplified service cards to display a single, streamlined price list.
  - Ensured consistent city information and pricing across the app for a clearer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->